### PR TITLE
Fix issue with room being full sometimes

### DIFF
--- a/packages/client/src/components/UserContext.tsx
+++ b/packages/client/src/components/UserContext.tsx
@@ -12,12 +12,12 @@ export const UserContext = createContext<{
 const persistedUsername = getStoredUsername();
 export const UserProvider: FC = ({ children }) => {
   const [username, setUsername] = useState<string>(persistedUsername ?? '');
-  const hasUsername = useRef(username !== '');
+  const isUsernameMissing = useRef(username === '');
 
   const handleUsernameCreated = (randomUsername: string) => {
     setUsername(randomUsername);
     persistUsername(randomUsername);
-    hasUsername.current = false;
+    isUsernameMissing.current = true;
   };
 
   useEffect(() => {
@@ -27,13 +27,13 @@ export const UserProvider: FC = ({ children }) => {
 
     // We check if username exists to avoid double-registering the callback.
     // Same for de-registering.
-    if (!hasUsername.current) {
+    if (isUsernameMissing.current) {
       gameIO.emit(UserEvent.UsernameMissing);
       gameIO.on(UserEvent.UsernameCreated, handleUsernameCreated);
     }
 
     return () => {
-      if (!hasUsername.current) {
+      if (isUsernameMissing.current) {
         gameIO.off(UserEvent.UsernameCreated, handleUsernameCreated);
       }
     };

--- a/packages/client/src/components/UserContext.tsx
+++ b/packages/client/src/components/UserContext.tsx
@@ -37,7 +37,7 @@ export const UserProvider: FC = ({ children }) => {
         gameIO.off(UserEvent.UsernameCreated, handleUsernameCreated);
       }
     };
-  }, [username]);
+  }, []);
 
   return (
     <UserContext.Provider value={{ username: username }}>{username ? children : 'Pending ...'}</UserContext.Provider>

--- a/packages/client/src/components/UserContext.tsx
+++ b/packages/client/src/components/UserContext.tsx
@@ -17,11 +17,13 @@ export const UserProvider: FC = ({ children }) => {
 
   useEffect(() => {
     gameIO.on('connect', () => {
-      if (!username) {
-        gameIO.emit(UserEvent.UsernameMissing);
-      }
       console.log(`connect ${gameIO.id}`);
     });
+
+    if (!username) {
+      gameIO.emit(UserEvent.UsernameMissing);
+    }
+
     const handleUsernameCreated = (randomUsername: string) => {
       setUsername(randomUsername);
       persistUsername(randomUsername);

--- a/packages/client/src/components/UserContext.tsx
+++ b/packages/client/src/components/UserContext.tsx
@@ -14,12 +14,12 @@ export const UserContext = createContext<{
 const persistedUsername = getStoredUsername();
 export const UserProvider: FC = ({ children }) => {
   const [username, setUsername] = useState<string>(persistedUsername ?? '');
-  if (!username) {
-    gameIO.emit(UserEvent.UsernameMissing);
-  }
 
   useEffect(() => {
     gameIO.on('connect', () => {
+      if (!username) {
+        gameIO.emit(UserEvent.UsernameMissing);
+      }
       console.log(`connect ${gameIO.id}`);
     });
     const handleUsernameCreated = (randomUsername: string) => {
@@ -30,7 +30,7 @@ export const UserProvider: FC = ({ children }) => {
     return () => {
       gameIO.off(UserEvent.UsernameCreated, handleUsernameCreated);
     };
-  }, []);
+  }, [username]);
 
   return (
     <UserContext.Provider value={{ username: username }}>{username ? children : 'Pending ...'}</UserContext.Provider>

--- a/packages/client/src/components/UserContext.tsx
+++ b/packages/client/src/components/UserContext.tsx
@@ -12,12 +12,12 @@ export const UserContext = createContext<{
 const persistedUsername = getStoredUsername();
 export const UserProvider: FC = ({ children }) => {
   const [username, setUsername] = useState<string>(persistedUsername ?? '');
-  const hasUserName = useRef(username !== '');
+  const hasUsername = useRef(username !== '');
 
   const handleUsernameCreated = (randomUsername: string) => {
     setUsername(randomUsername);
     persistUsername(randomUsername);
-    hasUserName.current = false;
+    hasUsername.current = false;
   };
 
   useEffect(() => {
@@ -27,13 +27,13 @@ export const UserProvider: FC = ({ children }) => {
 
     // We check if username exists to avoid double-registering the callback.
     // Same for de-registering.
-    if (!hasUserName.current) {
+    if (!hasUsername.current) {
       gameIO.emit(UserEvent.UsernameMissing);
       gameIO.on(UserEvent.UsernameCreated, handleUsernameCreated);
     }
 
     return () => {
-      if (!hasUserName.current) {
+      if (!hasUsername.current) {
         gameIO.off(UserEvent.UsernameCreated, handleUsernameCreated);
       }
     };

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -55,7 +55,6 @@ export function updateGameState(io: IOServer, store: Store, roomName: string, ga
       latestCaptured,
     };
     store.updateRoomState(roomName, updatedGameState);
-    console.info(GameEvent.CurrentState, updatedGameState);
     io.in(roomName).emit(GameEvent.CurrentState, updatedGameState);
   }
 }


### PR DESCRIPTION
`UserEvent.UsernameMissing` was randomly being emitted twice. That was because it was not inside `useEffect` (which I think should be). I also added a boolean to make sure we do not register and deregister callbacks when not needed.